### PR TITLE
fix: update API endpoint from /api/v1/registry to /api/v1/agents

### DIFF
--- a/src/lib/components/app-sidebar.svelte
+++ b/src/lib/components/app-sidebar.svelte
@@ -54,9 +54,9 @@
 			connecting = true;
 			error = null;
 			sessCtx.registry = null;
-			const agents = (await fetch(`http://${sessCtx.connection.host}/api/v1/registry`).then((res) =>
-				res.json()
-			)) as RegistryAgent[];
+					const agents = (await fetch(`http://${sessCtx.connection.host}/api/v1/agents`).then((res) =>
+			res.json()
+		)) as RegistryAgent[];
 			sessCtx.registry = Object.fromEntries(agents.map((agent) => [agent.id, agent]));
 
 			const sessions = (await fetch(`http://${sessCtx.connection.host}/api/v1/sessions`).then(

--- a/src/lib/components/server-switcher.svelte
+++ b/src/lib/components/server-switcher.svelte
@@ -43,7 +43,7 @@
 		testSuccess = null;
 		testing = true;
 		try {
-			const res = await fetch(`http://${host}/api/v1/registry`);
+			const res = await fetch(`http://${host}/api/v1/agents`);
 			await tick();
 			testSuccess = res.status === 200;
 		} catch {


### PR DESCRIPTION
- Fixes connection issue between coral-studio and coral-server
- coral-server exposes /api/v1/agents endpoint, not /api/v1/registry
- Updated both app-sidebar.svelte and server-switcher.svelte components
- Resolves issue where coral-studio couldn't connect to localhost:5555